### PR TITLE
bug_report.md: Does not need "Issue Type" field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Report problems and unexpected behavior
 
 ---
 
-- **Issue type:** <!-- bug report, feature request, or question? -->
 - **Sourcegraph version:** <!-- the version of Sourcegraph (if self-hosted), or "Sourcegraph.com" -->
 - **Platform:** <!-- OS version, cloud provider, web browser version, Docker version, etc., depending on the issue -->
 


### PR DESCRIPTION
The "Issue Type" field is only ever going to be "Bug Report"